### PR TITLE
Update README Travis Badge

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -9,8 +9,8 @@ Introduction
     :target: https://discord.gg/nBQh6qu
     :alt: Discord
 
-.. image:: https://travis-ci.org/adafruit/Adafruit_CircuitPython_VS1053.svg?branch=master
-    :target: https://travis-ci.org/adafruit/Adafruit_CircuitPython_VS1053
+.. image:: https://travis-ci.com/adafruit/Adafruit_CircuitPython_VS1053.svg?branch=master
+    :target: https://travis-ci.com/adafruit/Adafruit_CircuitPython_VS1053
     :alt: Build Status
 
 Driver for interacting and playing media files with the VS1053 audio codec over


### PR DESCRIPTION
Change 'travis-ci.org' to 'travis-ci.com'.